### PR TITLE
✨：結果へのパーマリンクの生成とXでシェアするボタンを追加。

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { LazyLoadImage } from 'react-lazy-load-image-component'
 import { question } from './types/question.ts'
 import './App.css'
@@ -7,6 +7,7 @@ import VTCard from './components/VTCard.tsx'
 import logo from './assets/logo.png'
 import { Liver } from './types/Liver.ts'
 import livers from './data/vts.json'
+import { createLink, getLiverListFromLink } from './utils/permanentlink.ts'
 
 function App() {
 	let vts = livers
@@ -142,7 +143,14 @@ function App() {
 			answer.push(tuple[0])
 			i++
 		}
+
+		setShareText(answer)
 		return answer
+	}
+
+	// 導き出したおすすめVTurerを取得する
+	function getAnswers(more: boolean) {
+		return more ? answers : answers.slice(0, 5)
 	}
 
 	// ランダムにVTuberを選ぶ
@@ -211,6 +219,14 @@ function App() {
 				return vt
 			}
 		)
+	}
+
+	/** xでシェアする際のテキストを設定 */
+	function setShareText(answer: Liver[]) {
+		const shareText = `そのぶいからあなたへのおすすめは「${answer[0].name}」です！\n${answer[0].yt}\n\n--\nそのぶいはVリスナーの皆さんの好みを選んでもらうことで好みに合うかもしれない VTuber をざっくりオススメするサービスです。\n\n`
+		createLink(answer).then(link => {
+			setShareLink('https://x.com/intent/post?text=' + encodeURIComponent(shareText + link))
+		})
 	}
 
 	// 質問20題くらい作る
@@ -463,6 +479,9 @@ function App() {
 
 	]
 
+	const [shareLink, setShareLink] = useState('')
+	const [answers, setAnswers] = useState<Liver[]>([])
+
 	const [more, setMore] = useState(false)
 	const [important, setImportant] = useState(-1)
 	const [choises, setChoises] = useState([
@@ -487,6 +506,11 @@ function App() {
 		addScoresByQuestion()
 
 		setAnswerCount(answerCount + 1)
+
+		// 結果を保存しておく
+		if (answerCount + 1 === questions.length) {
+			setAnswers(showResults(true))
+		}
 	}
 
 	function handleBack(): void {
@@ -500,6 +524,34 @@ function App() {
 		setChoises(nextChoises)
 
 	}
+
+	// パーマリンクから遷移した場合の処理
+	useEffect(() => {
+		if (location.search) {
+			// パーマリンクからぶいのリストを復元する
+			getLiverListFromLink()
+				.then((livers) => {
+					if (livers && livers.length > 0) {
+						setShareText(livers)
+						setAnswers(livers)
+						setMore(false)
+						setAnswerCount(questions.length)
+					} else {
+						// リンク不正 -> はじめに戻す
+						setChoises([
+							0,0,0,0,0,
+							0,0,0,0,0,
+							0,0,0,0,0,
+							0,0,0,0,0,
+							0,
+						])
+						setMore(false)
+						setAnswerCount(-1)
+						setImportant(-1)
+					}
+				})
+		}
+	}, [location.search])
 
 	return (
 		<>
@@ -556,7 +608,7 @@ function App() {
 				<p className="is-size-7 m-plus-rounded-1c-bold">いないかも</p>
 		}
 		<div>
-		{ answerCount >= 0 && important < 0 &&
+		{ answerCount >= 0 && important < 0 && answerCount < questions.length &&
 			<button className="m-2 button is-primary is-light m-plus-rounded-1c-regular" onClick={() => {
 			setImportant(answerCount)
 		}
@@ -597,10 +649,10 @@ function App() {
 		<div>
 		{ answerCount === questions.length && <h2>おすすめのVTuberは......</h2> }
 		{ answerCount === questions.length && <p className="is-size-7">※タップするとチャンネルが開きます</p> }
-		{ answerCount === questions.length && showResults(false || more).map(vtuber => <VTCard vtuber={vtuber} key={vtuber.name} />) }
+		{ answerCount === questions.length && getAnswers(more).map(vtuber => <VTCard vtuber={vtuber} key={vtuber.name} />) }
 		</div>
 		<div>
-		{ answerCount === questions.length && !more &&
+		{ answerCount === questions.length && !more && answers.length > 5 &&
 			<button className="m-2 button is-primary is-light m-plus-rounded-1c-bold" onClick={() => setMore(true)}
 		>おかわりする</button>
 		}
@@ -611,6 +663,12 @@ function App() {
 		{ answerCount === -100 && <p className="is-size-7 m-plus-rounded-1c-regular">※タップするとチャンネルが開きます</p> }
 		{ answerCount === -100 && <VTCard vtuber={randomPickVT()} /> }
 		</div>
+
+		{ answerCount === questions.length &&
+			<div>
+				<a href={shareLink} target='_blank' className="m-2 button is-primary is-light m-plus-rounded-1c-bold">Xでシェア</a>
+			</div>
+		}
 
 		<div>
 

--- a/src/utils/permanentlink.ts
+++ b/src/utils/permanentlink.ts
@@ -1,0 +1,78 @@
+import { Liver } from "../types/Liver.ts"
+import livers from '../data/vts.json'
+
+export const linkParameterKey: string = 'l'
+
+/** gzipで圧縮する */
+async function compress(str: string): Promise<string> {
+    const cs = new CompressionStream("gzip")
+    const buf = new TextEncoder().encode(str)
+    const stream = new Response(buf).body!.pipeThrough(cs)
+    const result = await new Response(stream).arrayBuffer()
+    // base64はそのままURLで使えないので、一部文字を置き換える
+    return btoa(String.fromCharCode(...new Uint8Array(result)))
+        .replace(/\+/g, '-')
+        .replace(/\\/g, '_')
+}
+
+/** gzipの伸張する */
+async function decompress(base64: string): Promise<string> {
+    const original = atob(base64.replace(/-/g, '+').replace(/_/g, '\\'))
+    const buffer = new Uint8Array(original.length)
+    for (let index = 0; index < original.length; ++index) {
+        buffer[index] = original.charCodeAt(index)
+    }
+    const ds = new DecompressionStream("gzip")
+    const stream = new Blob([buffer]).stream().pipeThrough(ds)
+    const buf = await new Response(stream).arrayBuffer()
+    return new TextDecoder('utf-8').decode(buf)
+}
+
+/** 絶対パスの生成 */
+function createUrl(version: number, query: string) {
+    return `${location.origin}${location.pathname}?v=${version}&${linkParameterKey}=${query}`
+}
+
+/**
+ * パーマリンクの生成
+ * ※リンクの生成方式が変わることを見越してバージョンを割り振っておく
+ */
+const v1 = {
+    /** パーマリンクを生成する */
+    async createLink(livers: Liver[]) {
+        const idList = JSON.stringify(livers.map(x => x.yt))
+        const parameter = await compress(idList)
+        return createUrl(1, parameter)
+    },
+
+    /** パーマリンクのsearchからライバーのリストを生成する */
+    async getLiverListFromLinkParameter(link: string): Promise<Liver[] | null> {
+        try {
+            const original = await decompress(link)
+            const idList = JSON.parse(original) as string[]
+            return idList
+                .map(x => livers.find(l => l.yt === x))
+                .filter(x => x)
+        } catch (e) {
+            return null
+        }
+    }
+}
+
+/** パーマリンクを生成する */
+export async function createLink(livers: Liver[]): Promise<string> {
+    return await v1.createLink(livers)
+}
+
+/** パーマリンクからライバーのリストを生成する */
+export async function getLiverListFromLink(): Promise<Liver[] | null> {
+    const parser = new URLSearchParams(location.search)
+    const query = parser.get(linkParameterKey)
+    const version = parser.get('v')
+    if (!query) { return null }
+
+    switch (version) {
+        case "1": return await v1.getLiverListFromLinkParameter(query)
+        default: return null
+    }
+}


### PR DESCRIPTION
パーマリンクの生成機能
==

結果のV一覧が表示されている画面を直接開くためのURLの生成と、そのURLをXでポストする為のボタンの追加をしています。
不具合あったらごめんなさい。。。

## 変更点
- utilsフォルダ追加
  - リンクを生成するユーティリティを追加
- 結果の表示部分をリンクから生成できるように細々調整
- シェアボタンを追加

### utilsフォルダ追加
いい感じのフォルダがなかったので勝手に追加しました。

### リンクを生成するユーティリティを追加
選択されたVのリンク(yt)のリストをシリアライズしてURLに変換します。

### 結果の表示部分をリンクから生成できるように細々調整
`showResults` で結果を表示していましたが、結果を一度変数に保存するように変更しています。
dom生成時は `showResults` ではなく、保存されている変数から描画するように変更しています。

### シェアボタンを追加
Xでシェアするボタンをおかわりボタンの下に追加しました。
localhostの場合はX上でURLとみなされないので、文字数オーバーになって投稿できません。